### PR TITLE
Add SAT mass download demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# sat-downloader
-descargar facturas del sat
+# SAT Downloader
+
+Esta herramienta proporciona un ejemplo sencillo para automatizar la descarga masiva de facturas CFDI desde los servicios web del SAT. Incluye una interfaz gráfica muy básica desarrollada en Python para usuarios que no tienen conocimientos de programación.
+
+**Aviso**: Los endpoints reales del SAT no se incluyen en este código. Deberás reemplazar las URL de `sat_api.py` con las direcciones correctas proporcionadas por el SAT. Además, este repositorio se ofrece con fines educativos y podría requerir ajustes adicionales para funcionar en producción.
+
+## Requisitos
+
+- Python 3.12 o superior
+- Paquetes indicados en `requirements.txt`
+- Certificados vigentes (.cer y .key) y contraseña de la FIEL
+
+Instala las dependencias con:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso rápido
+
+Ejecuta la interfaz gráfica con:
+
+```bash
+python -m sat_downloader.gui
+```
+
+1. Ingresa tu RFC.
+2. Selecciona los archivos `.cer` y `.key`.
+3. Ingresa la contraseña de la llave.
+4. Especifica el rango de fechas (por ejemplo, 2019-01-01 a 2025-12-31).
+5. Elige el directorio de salida para guardar las facturas.
+6. Presiona **Iniciar descarga**.
+
+La aplicación intentará autenticarte y descargar los paquetes disponibles de manera secuencial, mostrando el progreso.
+
+## Advertencia
+
+Debido a las restricciones de acceso a los dominios del SAT en este entorno, no fue posible realizar pruebas de conexión con los servicios reales. Asegúrate de contar con acceso a internet y con las URLs oficiales antes de ejecutar en un entorno de producción.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/sat_downloader/gui.py
+++ b/sat_downloader/gui.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Simple desktop GUI for downloading CFDI invoices from SAT."""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from . import sat_api
+
+
+def _run_download(
+    params: dict,
+    prog: ttk.Progressbar,
+    info_var: tk.StringVar,
+) -> None:
+    """Background thread for running the download process."""
+
+    def on_batch(total: int, _current: int) -> None:
+        prog.config(maximum=total)
+        info_var.set(f"Total paquetes: {total}")
+
+    def on_progress(current: int, total: int) -> None:
+        prog["value"] = current
+        info_var.set(f"Descargando paquete {current}/{total}")
+
+    try:
+        sat_api.download_invoices(
+            params["rfc"],
+            params["cer"],
+            params["key"],
+            params["password"],
+            params["start_date"],
+            params["end_date"],
+            batch_callback=on_batch,
+            progress_callback=on_progress,
+            output_dir=params["output_dir"],
+        )
+        messagebox.showinfo("Finalizado", "Descarga completada")
+    except Exception as exc:  # pylint: disable=broad-except
+        messagebox.showerror("Error", str(exc))
+    finally:
+        prog.stop()
+
+
+def start_gui() -> None:
+    """Launch the Tkinter GUI."""
+    root = tk.Tk()
+    root.title("SAT Descarga Masiva")
+
+    frm = ttk.Frame(root, padding=10)
+    frm.grid()
+
+    # RFC
+    ttk.Label(frm, text="RFC:").grid(column=0, row=0, sticky=tk.W)
+    rfc_entry = ttk.Entry(frm, width=30)
+    rfc_entry.grid(column=1, row=0)
+
+    # Cert and key
+    ttk.Label(frm, text="Certificado (.cer):").grid(
+        column=0, row=1, sticky=tk.W
+    )
+    cer_entry = ttk.Entry(frm, width=30)
+    cer_entry.grid(column=1, row=1)
+    ttk.Button(
+        frm,
+        text="...",
+        command=lambda: cer_entry.insert(0, filedialog.askopenfilename()),
+    ).grid(column=2, row=1)
+
+    ttk.Label(frm, text="Llave (.key):").grid(column=0, row=2, sticky=tk.W)
+    key_entry = ttk.Entry(frm, width=30)
+    key_entry.grid(column=1, row=2)
+    ttk.Button(
+        frm,
+        text="...",
+        command=lambda: key_entry.insert(0, filedialog.askopenfilename()),
+    ).grid(column=2, row=2)
+
+    ttk.Label(frm, text="Contraseña Key:").grid(column=0, row=3, sticky=tk.W)
+    pwd_entry = ttk.Entry(frm, width=30, show="*")
+    pwd_entry.grid(column=1, row=3)
+    # Dates
+    ttk.Label(frm, text="Fecha inicio (YYYY-MM-DD):").grid(
+        column=0, row=4, sticky=tk.W
+    )
+    start_entry = ttk.Entry(frm, width=30)
+    start_entry.grid(column=1, row=4)
+
+    ttk.Label(frm, text="Fecha fin (YYYY-MM-DD):").grid(
+        column=0, row=5, sticky=tk.W
+    )
+    end_entry = ttk.Entry(frm, width=30)
+    end_entry.grid(column=1, row=5)
+
+    ttk.Label(frm, text="Directorio de salida:").grid(
+        column=0, row=6, sticky=tk.W
+    )
+    out_entry = ttk.Entry(frm, width=30)
+    out_entry.grid(column=1, row=6)
+    ttk.Button(
+        frm,
+        text="...",
+        command=lambda: out_entry.insert(0, filedialog.askdirectory()),
+    ).grid(column=2, row=6)
+
+    prog = ttk.Progressbar(frm, length=200, mode="determinate")
+    prog.grid(column=0, row=7, columnspan=3, pady=5)
+
+    info_var = tk.StringVar(value="Esperando...")
+    ttk.Label(frm, textvariable=info_var).grid(column=0, row=8, columnspan=3)
+
+    def on_start() -> None:
+        params = {
+            "rfc": rfc_entry.get().strip(),
+            "cer": cer_entry.get().strip(),
+            "key": key_entry.get().strip(),
+            "password": pwd_entry.get().strip(),
+            "start_date": dt.datetime.strptime(
+                start_entry.get().strip(), "%Y-%m-%d"
+            ).date(),
+            "end_date": dt.datetime.strptime(
+                end_entry.get().strip(), "%Y-%m-%d"
+            ).date(),
+            "output_dir": out_entry.get().strip() or "downloads",
+        }
+        prog.config(value=0)
+        threading.Thread(
+            target=_run_download, args=(params, prog, info_var), daemon=True
+        ).start()
+
+    ttk.Button(frm, text="Iniciar descarga", command=on_start).grid(
+        column=0, row=9, columnspan=3, pady=10
+    )
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    start_gui()

--- a/sat_downloader/sat_api.py
+++ b/sat_downloader/sat_api.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Helpers for communicating with SAT mass download services.
+
+This module contains simplified wrappers around the SAT web service
+for CFDI mass downloads. Endpoints must be filled with the real SAT
+URLs. Functions are designed to be used by the GUI application and are
+intended for educational purposes. They do not implement the full SAT
+protocol but show the general structure required.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import time
+import zipfile
+from typing import Callable, Iterable, List
+
+import requests
+
+# Placeholder endpoints (replace with actual SAT URLs)
+AUTH_URL = "https://example.com/sat/auth"
+QUERY_URL = "https://example.com/sat/query"
+DOWNLOAD_URL = "https://example.com/sat/download"
+
+
+class SATAPIError(Exception):
+    """Raised when the SAT API returns an error."""
+
+
+def authenticate(cer_path: str, key_path: str, password: str) -> str:
+    """Authenticate with the SAT and return a security token.
+
+    The actual implementation should sign the request with the user's
+    certificate and private key and send it to the SAT authentication
+    endpoint. This simplified version performs an HTTP POST request
+    and expects a JSON response containing a token.
+    """
+
+    with open(cer_path, "rb") as cer_file, open(key_path, "rb") as key_file:
+        files = {"cer": cer_file, "key": key_file}
+        data = {"password": password}
+        resp = requests.post(AUTH_URL, files=files, data=data, timeout=30)
+    resp.raise_for_status()
+    token = resp.json().get("token")
+    if not token:
+        raise SATAPIError("Token not found in response")
+    return token
+
+
+def query_available_packages(
+    token: str,
+    rfc: str,
+    start: _dt.date,
+    end: _dt.date,
+) -> List[str]:
+    """Request the list of download package identifiers for the given range."""
+    payload = {
+        "rfc": rfc,
+        "fechaInicial": start.isoformat(),
+        "fechaFinal": end.isoformat(),
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.post(QUERY_URL, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("packages", [])
+
+
+def download_package(token: str, package_id: str, output_dir: str) -> str:
+    """Download a single package and return the path to the ZIP file."""
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.get(
+        f"{DOWNLOAD_URL}/{package_id}",
+        headers=headers,
+        stream=True,
+        timeout=60,
+    )
+    resp.raise_for_status()
+    zip_path = os.path.join(output_dir, f"{package_id}.zip")
+    with open(zip_path, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            fh.write(chunk)
+    return zip_path
+
+
+def extract_zip(zip_path: str, output_dir: str) -> Iterable[str]:
+    """Extract XML files from a ZIP archive and yield their paths."""
+    with zipfile.ZipFile(zip_path) as zf:
+        for info in zf.infolist():
+            if not info.filename.lower().endswith(".xml"):
+                continue
+            dest = os.path.join(output_dir, info.filename)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "wb") as fh, zf.open(info) as src:
+                fh.write(src.read())
+            yield dest
+
+
+def download_invoices(
+    rfc: str,
+    cer_path: str,
+    key_path: str,
+    password: str,
+    start: _dt.date,
+    end: _dt.date,
+    batch_callback: Callable[[int, int], None] | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
+    output_dir: str = "downloads",
+) -> None:
+    """Download all invoices for the RFC in the given date range."""
+    token = authenticate(cer_path, key_path, password)
+    packages = query_available_packages(token, rfc, start, end)
+    total = len(packages)
+    if batch_callback:
+        batch_callback(total, 0)
+    for idx, pkg in enumerate(packages, 1):
+        try:
+            zip_path = download_package(token, pkg, output_dir)
+            extract_zip(zip_path, output_dir)
+            if progress_callback:
+                progress_callback(idx, total)
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"Failed to download package {pkg}: {exc}")
+        time.sleep(1)  # avoid hammering the server


### PR DESCRIPTION
## Summary
- add basic example for SAT mass download with placeholder endpoints
- provide extremely simple Tkinter GUI
- document usage in README

## Testing
- `flake8 sat_downloader`
- `python -m sat_downloader.gui` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6854dd014f08832582effd8fa3fe6300